### PR TITLE
System gcc fixes

### DIFF
--- a/sw/Makefile
+++ b/sw/Makefile
@@ -58,7 +58,7 @@ LFLAGS     := $(CFLAGS) $(ADD_LFLAGS) -L$(LD_DIR) \
 			  -nostdlib \
 			  -Wl,--gc-sections \
 			  -Wl,--no-warn-mismatch \
-			  -Wl,--script=$(LDSCRIPT) \
+			  -T$(LDSCRIPT) \
 			  -Wl,--build-id=none
 
 OBJ_DIR    := .obj

--- a/sw/Makefile
+++ b/sw/Makefile
@@ -6,6 +6,7 @@ ifneq (,$(shell which riscv-none-embed-gcc))
 TRGT       ?= riscv-none-embed-
 else
 TRGT       ?= riscv64-unknown-elf-
+SPECS      ?= -specs=picolibc.specs
 endif
 endif
 
@@ -44,7 +45,7 @@ SRC_DIR    := $(BASE_DIR)/src
 THIRD_PARTY := $(BASE_DIR)/third_party
 DBG_CFLAGS := -ggdb3 -DDEBUG -Wall
 DBG_LFLAGS := -ggdb3 -Wall
-CFLAGS     := $(ADD_CFLAGS) \
+CFLAGS     := $(ADD_CFLAGS) $(SPECS) \
 			  -D__vexriscv__ -march=rv32i  -mabi=ilp32 \
 			  -Wall -Wextra \
 			  -flto \


### PR DESCRIPTION
This allows me to use the riscv toolchain and riscv picolibc shipped by Debian. I tested with the version in testing (1.7.4-1 for picolibc).

```
apt install picolibc-riscv64-unknown-elf gcc-riscv64-unknown-elf
```

This assumes the user has the picolibc package installed if the compiler is riscv64-unknown-elf. That may not be always true, so I am open to alternate suggestions.